### PR TITLE
eliminate external dependence and plots to screen

### DIFF
--- a/calculate_norm_area_weight.py
+++ b/calculate_norm_area_weight.py
@@ -1,6 +1,13 @@
 from xspec import *
 import os, argparse
-from find_directory import read_file
+
+def read_file(filename):
+    if os.path.exists(filename):    
+        with open(filename,'r') as f:
+            lines = f.readlines()
+        return lines
+    else:
+        return None
 
 def find_file_extension(dir_path, ext):
     res=[]

--- a/calibratemodel_gainfit.sh
+++ b/calibratemodel_gainfit.sh
@@ -45,7 +45,7 @@ fi
 if [ "$CLOB" = "yes" ] || [ "$CLOB" = "no" -a ! -e "$XCM" ]; then
     echo -e "Calibrating the spectral model...\n"
     echo "Fitting energy range: 9.0-11.5 keV"
-    echo "cpd /xs" >$XCM
+    echo "cpd /none" >$XCM # echo "cpd /xs" >$XCM
     echo "setp e" >>$XCM
     echo "setp com cs 1.3" >>$XCM
     echo "statistic cstat" >>$XCM
@@ -104,8 +104,8 @@ if [ "$CLOB" = "yes" ] || [ "$CLOB" = "no" -a ! -e "$XCM" ]; then
     echo "cpd ${IMG}/cps" >>$XCM
     echo "pl ld ra" >>$XCM
     echo "cpd none" >>$XCM
-    echo "cpd /xs" >>$XCM
-    echo "pl ld ra" >>$XCM
+    #echo "cpd /xs" >>$XCM
+    #echo "pl ld ra" >>$XCM
     echo "save mo ${OUTMODEL}" >>$XCM
 
     echo "log ${LOG2}" >>$XCM

--- a/calibratemodel_gainfit_nofit.sh
+++ b/calibratemodel_gainfit_nofit.sh
@@ -44,7 +44,7 @@ fi
 if [ "$CLOB" = "yes" ] || [ "$CLOB" = "no" -a ! -e "$XCM" ]; then
     echo -e "Calibrating the spectral model...\n"
     echo "Fitting energy range: 9.0-11.5 keV"
-    echo "cpd /xs" >$XCM
+    echo "cpd /none" > $XCM  #echo "cpd /xs" >$XCM
     echo "setp e" >>$XCM
     echo "setp com cs 1.3" >>$XCM
     echo "statistic cstat" >>$XCM
@@ -93,8 +93,8 @@ if [ "$CLOB" = "yes" ] || [ "$CLOB" = "no" -a ! -e "$XCM" ]; then
     echo "cpd ${IMG}/cps" >>$XCM
     echo "pl ld ra" >>$XCM
     echo "cpd none" >>$XCM
-    echo "cpd /xs" >>$XCM
-    echo "pl ld ra" >>$XCM
+    #echo "cpd /xs" >>$XCM
+    #echo "pl ld ra" >>$XCM
     echo "save mo ${OUTMODEL}" >>$XCM
 
     echo "log ${LOG2}" >>$XCM


### PR DESCRIPTION
Removes an undocumented dependence on the `read_file` "function".

I also attempted to disable all XSEPC plots that pop up to the screen, but appear not to have squashed them all. @leogulus , do you know where else this might be done?